### PR TITLE
Add Rafal (temporary) as Codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @soadeyemo @tanjadegroot
+* @soadeyemo @tanjadegroot @rartych
 
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management

#### What this PR does / why we need it:

Adding @rartych as Codeowner during the vacation period to ensure that Release Management can still be managed.

#### Which issue(s) this PR fixes:

