### PR TITLE
Update README.md with updated URLs to new Cloud based wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,23 @@ Beyond the above reference release management information in GitHub, more inform
 
 * **Meta-releases of CAMARA**
 
-  * [Meta-release Plans](https://wiki.camaraproject.org/x/2qN3)
-  * [Meta-release Process](https://wiki.camaraproject.org/x/G7N3)
+  * [Meta-release Plans](https://lf-camaraproject.atlassian.net/wiki/x/bmTe)
+  * [Meta-release Process](https://lf-camaraproject.atlassian.net/wiki/x/Zwne)
 
 * **API release management**
-  * [API Release Process](https://wiki.camaraproject.org/x/AgAVAQ)
-  * [API Release Tracking Process](https://wiki.camaraproject.org/x/HQBFAQ)
-  * [More on API Readiness Checklist](https://wiki.camaraproject.org/display/CAM/API+Release+Process#APIReleaseProcess-APIreadinesschecklist)
-  * [More on API Versioning](https://wiki.camaraproject.org/display/CAM/API+versioning)
+  * [API Release Process](https://lf-camaraproject.atlassian.net/wiki/x/jine)
+  * [API Release Tracking Process](https://lf-camaraproject.atlassian.net/wiki/x/ZhHe)
+  * [More on API Readiness Checklist](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14559630/API+Release+Process#API-readiness-checklist)
+  * [More on API Versioning](https://lf-camaraproject.atlassian.net/wiki/x/3yLe)
 
 More information about processes and release numbering for Commonalities and ICM can be found here:
 
-  * [Commonalities and ICM Release Process](https://wiki.camaraproject.org/display/CAM/Meta-release+Process#MetareleaseProcess-CommonalitiesandICM)
+  * [Commonalities and ICM Release Process](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14551399/Meta-release+Process#Commonalities-and-ICM)
 
 ## Contributing
 * Meeting link: [Meeting Registration / Join](https://zoom-lfx.platform.linuxfoundation.org/meeting/97762557636?password=e5f98402-8c29-448d-a8b1-f2dceaa9d4ba)
 * Schedule: Weekly on Tuesday's at 08:00 PT / 16:00 UTC / 17:00 CET
-* Meeting minutes are available within the [wiki of the Release Management Working Group](https://wiki.camaraproject.org/display/CAM/Release+Management+Working+Group)
+* Meeting minutes are available within the [wiki of the Release Management Working Group](https://lf-camaraproject.atlassian.net/wiki/x/VA7e)
 
 ## Contributorship and mailing list
 * Subscribe / Unsubscribe to the mailing list of this Working Group <https://lists.camaraproject.org/g/wg-release-management>.


### PR DESCRIPTION
Replacing wiki links with new domain URLs after cloud migration.

#### What type of PR is this?

Add one of the following kinds:

* correction
