### PR TITLE
Update CODEOWNERS - adding Herbert

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @soadeyemo @tanjadegroot @rartych
+* @soadeyemo @tanjadegroot @rartych @hdamker
 
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins


### PR DESCRIPTION
As discussed with Herbert adding him to the CODEOWNERS of the ReleaseManagement repository

#### What type of PR is this?

Add one of the following kinds:
* subproject management


#### What this PR does / why we need it:

Adding  @hdamker to the codeowners list of Release Management


#### Which issue(s) this PR fixes:
no issues neede for CODEOWNERS update
