### PR TITLE
PR for public RM release M4 Spring25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ It describes the processesand artifacts for use in the Release Management of the
 
 * Update issue_review_template.md by @hdamker in https://github.com/camaraproject/ReleaseManagement/pull/159
 * 168 update review issue template by @hdamker in https://github.com/camaraproject/ReleaseManagement/pull/170
+* Update api release guidelines by @tanjadegroot in https://github.com/camaraproject/ReleaseManagement/pull/118
+* Updates to API readiness checklist by @tanjadegroot in https://github.com/camaraproject/ReleaseManagement/pull/116
+* Update changelog template & example by @tanjadegroot in https://github.com/camaraproject/ReleaseManagement/pull/117
 
 **Full Changelog**: https://github.com/camaraproject/ReleaseManagement/compare/r1.2...r2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ It describes the processesand artifacts for use in the Release Management of the
 
 ### Changed
 
-* Update issue_review_template.md by @hdamker in https://github.com/camaraproject/ReleaseManagement/pull/159
-* 168 update review issue template by @hdamker in https://github.com/camaraproject/ReleaseManagement/pull/170
 * Update api release guidelines by @tanjadegroot in https://github.com/camaraproject/ReleaseManagement/pull/118
 * Updates to API readiness checklist by @tanjadegroot in https://github.com/camaraproject/ReleaseManagement/pull/116
 * Update changelog template & example by @tanjadegroot in https://github.com/camaraproject/ReleaseManagement/pull/117

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,25 @@
 
 ## Table of Contents
 
+- **[r2.2](#r22)**
 - **[r2.1](#r21)**
 - **[r1.2](#r12)**
 - **[r1.1](#r11)**
+
+# r2.2
+
+## Release Notes
+
+**This is the public release of the Release Management documents for use in the Spring25 meta-release with version v0.3.0.**
+
+It describes the processesand artifacts for use in the Release Management of the Spring25 meta-release. It includes the feedback from the Fall24 meta-release.
+
+### Changed
+
+* Update issue_review_template.md by @hdamker in https://github.com/camaraproject/ReleaseManagement/pull/159
+* 168 update review issue template by @hdamker in https://github.com/camaraproject/ReleaseManagement/pull/170
+
+**Full Changelog**: https://github.com/camaraproject/ReleaseManagement/compare/r1.2...r2.2
 
 # r2.1
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It contains the Release Management released documents and assests in the **docum
 It also contains the following in the **documentation/SupportingDocuments** folder:
    - [CHANGELOG_EXAMPLE.md](/documentation/SupportingDocuments/CHANGELOG_EXAMPLE.md) - Pointers to example CHANGELOG.md files over multiple releases created following the release management guidelines.
 
-For the reference documentation on API versioning, please see Chapter 5 in the API Design Guidelines document in [Commonalities](https://github.com/camaraproject/Commonalities).
+For the reference documentation on API versioning, please see "Versioning" section in the API Design Guidelines document in [Commonalities](https://github.com/camaraproject/Commonalities).
 
 The [CHANGELOG.md](/CHANGELOG.md) file describes the differences between releases of the Release Management repository.  
 

--- a/VERSION.yaml
+++ b/VERSION.yaml
@@ -1,1 +1,1 @@
-version: 0.3.0-rc.1
+version: 0.3.0


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation
* subproject management


#### What this PR does / why we need it:

Updates the information as needed to create the public release of the RM documentation


#### Which issue(s) this PR fixes:

Fixes #169 

