### PR TITLE
Release review issue template for Fall25 M3

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_review_template_fall25_m3.md
+++ b/.github/ISSUE_TEMPLATE/issue_review_template_fall25_m3.md
@@ -31,7 +31,7 @@ Put a short summary of the main review result as a comment here into the review 
 - [ ] changelog updated (structure in line with template, for public release all changes since last public release must be listed, Commonalities & ICM release candidates referred)
 - [ ] readme updated (correct naming "pre-release" and release number, API versions naming, alignment with template) 
 - [ ] API readiness checklist(s) (check link to Commonalities and ICM r3.2)
-- [ ] API description within wiki (check if existing, request to open issue for update until M4)
+- [ ] API description (ensure that the API readiness checklists have been updated with the additional line for the API Description and contains the link to the current API descriptions)
 
 Specific checks for alignment with Commonalities r3.2:
 - [ ] ... (TDB)

--- a/.github/ISSUE_TEMPLATE/issue_review_template_fall25_m3.md
+++ b/.github/ISSUE_TEMPLATE/issue_review_template_fall25_m3.md
@@ -28,11 +28,12 @@ Put a short summary of the main review result as a comment here into the review 
 
 - [ ] API definition files updated (YAML) (version in info & servers objects, check for links into main or older releases)  
 - [ ] test definition file(s) (availability, version infos and resource URLs)
-- [ ] changelog updated (structure in line with template, for public release all changes since last public release must be listed, Commonalities & ICM public releases)
-- [ ] readme updated (correct naming "Public release" and release number, API versions naming, alignment with template) 
-- [ ] API readiness checklist(s) (check link to Commonalities and ICM r2.3, for stable APIs, check for link to "test result statement" issue)
+- [ ] changelog updated (structure in line with template, for public release all changes since last public release must be listed, Commonalities & ICM release candidates referred)
+- [ ] readme updated (correct naming "pre-release" and release number, API versions naming, alignment with template) 
+- [ ] API readiness checklist(s) (check link to Commonalities and ICM r3.2)
+- [ ] API description within wiki (check if existing, request to open issue for update until M4)
 
-Specific checks for APIs with subscriptions/notifications, that the following PRs are applied to be aligned with Commonalities r3.2:
+Specific checks for alignment with Commonalities r3.2:
 - [ ] ... (TDB)
 
 **Release actions**

--- a/.github/ISSUE_TEMPLATE/issue_review_template_fall25_m3.md
+++ b/.github/ISSUE_TEMPLATE/issue_review_template_fall25_m3.md
@@ -1,6 +1,6 @@
 ---
 name: 💡 Fall25 M3 Review 🌟
-about: Request the review of a Spring25 M3 release PR by the Release Mgmt team
+about: Request the review of a Fall25 M3 release PR by the Release Mgmt team
 title: '$repo name$ $releasenr$ (Fall25 M3) release review'
 labels: 'Fall25 M3 review'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/issue_review_template_fall25_m3.md
+++ b/.github/ISSUE_TEMPLATE/issue_review_template_fall25_m3.md
@@ -62,7 +62,7 @@ When done, tick the box in this issue (requires write access, leave a comment ot
 - [ ] Release created within GitHub (by API repository codeowner)
 - [ ] Release Tracker updated (with creation date of the release and the release tag link)
 
-(Note: for public releases within Spring25 M4 the updates of GitHub README, CAMARA website and within API Backlog list will be done in batch as part of M5.)
+(Note: for pre-releases there is no update needed of website and other places. For public releases within Fall25 M4 the updates of GitHub README, CAMARA website and within API Backlog list will be done in batch as part of M5 milestone.)
 
 **Additional comments**
 <!-- Add any other comments here as needed. -->

--- a/.github/ISSUE_TEMPLATE/issue_review_template_fall25_m3.md
+++ b/.github/ISSUE_TEMPLATE/issue_review_template_fall25_m3.md
@@ -1,8 +1,8 @@
 ---
-name: 💡 Spring M4 Review 🌟
-about: Request the review of a Spring25 M4 release PR by the Release Mgmt team
-title: '$repo name$ $releasenr$ (Spring25 M4) release review'
-labels: 'Spring25 M4 review'
+name: 💡 Fall25 M3 Review 🌟
+about: Request the review of a Spring25 M3 release PR by the Release Mgmt team
+title: '$repo name$ $releasenr$ (Fall25 M3) release review'
+labels: 'Fall25 M3 review'
 assignees: ''
 
 ---
@@ -32,23 +32,15 @@ Put a short summary of the main review result as a comment here into the review 
 - [ ] readme updated (correct naming "Public release" and release number, API versions naming, alignment with template) 
 - [ ] API readiness checklist(s) (check link to Commonalities and ICM r2.3, for stable APIs, check for link to "test result statement" issue)
 
-Specific checks for APIs with subscriptions/notifications, that the following PRs are applied to be aligned with Commonalities r2.3:
-- [ ] Added note and changed descriptions for date-time formats in subscriptions in [#404](https://github.com/camaraproject/Commonalities/pull/404)
-- [ ] Sink format corrected in [#414](https://github.com/camaraproject/Commonalities/pull/414/files) and [#421](https://github.com/camaraproject/Commonalities/pull/421) (from `url` to `uri`)
-- [ ] Error 429 aligned for event-subscription-template.yaml and notification-as-cloud-event.yaml in [#407](https://github.com/camaraproject/Commonalities/pull/407/files) and [#408](https://github.com/camaraproject/Commonalities/pull/408/files)
-- [ ] Removed sinkCredential from Subscription schema in event-subscription-template.yaml in [#400](https://github.com/camaraproject/Commonalities/pull/400) (The sinkCredential must not be present in POST and GET responses)
-
-Specific request to API Repositories promoted to "Incubating" stage:
-- [ ] Badge "Incubating API Repository" applied in README
-- [ ] Text in README aligned with [template README.md](https://github.com/camaraproject/Template_API_Repository/blob/main/README.md) (see code)
-- [ ] Line "Incubating stage since: February 2025" added
+Specific checks for APIs with subscriptions/notifications, that the following PRs are applied to be aligned with Commonalities r3.2:
+- [ ] ... (TDB)
 
 **Release actions**
 
 Assign this issue to yourself or another RM team member and follow the below list. 
 When done, tick the box in this issue (requires write access, leave a comment otherwise). 
 
-- [ ] Short link to release review issue added to release trackers ("M4 #nnn")
+- [ ] Short link to release review issue added to release trackers ("M3 #nnn")
 - [ ] Review comments provided (on behalf of Release Management)
 - [ ] Review comments addressed (by release PR editor)
 - [ ] Release PR approved (on behalf of Release Management)
@@ -56,7 +48,7 @@ When done, tick the box in this issue (requires write access, leave a comment ot
 - [ ] Release created within GitHub (by API repository codeowner)
 - [ ] Release Tracker updated (with creation date of the release and the release tag link)
 
-Note: for public releases within Spring25 M4 the updates of GitHub README, CAMARA website and within API Backlog list will be done in batch as part of M5.
+(Note: for public releases within Spring25 M4 the updates of GitHub README, CAMARA website and within API Backlog list will be done in batch as part of M5.)
 
 **Additional comments**
 <!-- Add any other comments here as needed. -->

--- a/.github/ISSUE_TEMPLATE/issue_review_template_fall25_m3.md
+++ b/.github/ISSUE_TEMPLATE/issue_review_template_fall25_m3.md
@@ -34,7 +34,20 @@ Put a short summary of the main review result as a comment here into the review 
 - [ ] API description (ensure that the API readiness checklists have been updated with the additional line for the API Description and contains the link to the current API descriptions)
 
 Specific checks for alignment with Commonalities r3.2:
-- [ ] ... (TDB)
+See Analysis here:  https://lf-camaraproject.atlassian.net/wiki/x/uoDIBg
+
+- [ ] Remove the 401 AUTHENTICATION_REQUIRED code 
+- [ ] Mandatory text on non-documented error responses
+- [ ] remove IDENTIFIER_MISMATCH error and add response
+- [ ] Mandatory text proposed when duration string format is used
+- [ ] Update x-correlator pattern
+
+For Subscription APIs:
+
+- [ ] Update types property of Subscription to allow allowing more than one event type per subscription (optional)
+- [ ] 3.2. subscription-begins event
+- [ ] 3.3 subscription-updates event
+- [ ] Add sink pattern and specific 400 - INVALID_SINK error
 
 **Release actions**
 


### PR DESCRIPTION

#### What type of PR is this?

Add one of the following kinds:

* subproject management

#### What this PR does / why we need it:

Adapting the Spring25 M4 release review template for the upcoming Fall25 M3 release review phase.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #207 

#### Special notes for reviewers:

The template is not yet complete, we need to add the specific points we want to check during the M3 review, also depending on the upcoming Commonalities r3.2

Nevertheless we should have the template soon.

