### PR TITLE
Update API-Readiness-Checklist.md - removed links

### DIFF
--- a/documentation/API-Readiness-Checklist.md
+++ b/documentation/API-Readiness-Checklist.md
@@ -6,17 +6,17 @@ Checklist for api-name api-version in rx.y.
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
 |  1 | API definition                               |   M   |         M         |    M    |    M   |      | [relative link](/code/API_definitions/apiname.yaml) |
 |  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |      | Comm. release nr |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |      | ICM release nr |
-|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |      |   |
-|  5 | API documentation                            |   M   |         M         |    M    |    M   |      | [relative link](/documentation/API_documentation/apiname-API-Readiness-Checklist.md) |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |      | ICM release nr   |
+|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |      |                  |
+|  5 | API documentation                            |   M   |         M         |    M    |    M   |      | "inline in YAML" OR relative link to additional documentation |
 |  6 | User stories                                 |   O   |         O         |    O    |    M   |      | [relative link](/documentation/API_documentation/apiname-Userstory.md) |
 |  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |      | [relative link](/code/Test_definitions) |
 |  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |      | [relative link](/code/Test_definitions) |
-|  9 | Test result statement                        |   O   |         O         |    O    |    M   |      | issue link |
-| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |      |   |
+|  9 | Test result statement                        |   O   |         O         |    O    |    M   |      | issue link       |
+| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |      |                  |
 | 11 | Change log updated                           |   M   |         M         |    M    |    M   |      | [relative link](/CHANGELOG.md) |
-| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |      | comment |
-| 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |      | [Wiki link](https://lf-camaraproject.atlassian.net/wiki/) |
+| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |      | comment          |
+| 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |      | wiki link |
 
 To fill the checklist:
 - in the line above the table, replace the api-name, api-version and the rx.y by their actual values for the current API version and release.


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* cleanup
* documentation

#### What this PR does / why we need it:

Proposal to remove some of the predefined links within the template:
* line 5: link pointed to the checklist itself. In most cases is here no link needed
* line 13: "wiki link" pointed to the wiki main home page, aligned with line 9 which has also no example link

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # none ... is related to the work in https://github.com/camaraproject/project-administration/issues/11

