### PR TITLE
Update api-review-trigger.yml to fix tooling/issues/32

### DIFF
--- a/.github/workflows/api-review-trigger.yml
+++ b/.github/workflows/api-review-trigger.yml
@@ -63,6 +63,8 @@ jobs:
     steps:
       - name: Check Comment Trigger
         id: check
+        env:
+          COMMENT_BODY: ${{ toJSON(github.event.comment.body) }}
         run: |
           # Check if this is a comment event
           if [[ "${{ github.event_name }}" != "issue_comment" ]]; then
@@ -81,7 +83,7 @@ jobs:
           fi
           
           # Use jq to safely extract comment body and get first line only
-          COMMENT_FIRST_LINE=$(echo '${{ toJSON(github.event.comment.body) }}' | jq -r '. | split("\n")[0]')
+          COMMENT_FIRST_LINE=$(echo "$COMMENT_BODY" | jq -r '. | split("\n")[0]')
           
           echo "💬 Comment first line: '$COMMENT_FIRST_LINE'"
           


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction

#### What this PR does / why we need it:

This PR applies the fix for https://github.com/camaraproject/tooling/issues/32
It is the same fix as proposed in https://github.com/camaraproject/tooling/pull/33

It will avoid failed workflow runs as seen in
* https://github.com/camaraproject/ReleaseManagement/actions/runs/16250139807 and
* https://github.com/camaraproject/ReleaseManagement/actions/runs/16222191055

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # see https://github.com/camaraproject/tooling/issues/32

#### Special notes for reviewers:

The fix does not impact actual triggers for the api-review workflows but ensures that the workflow will not fail for other comments.
