### PR TITLE
docs: C2 release creation detailed design for review

### DIFF
--- a/documentation/SupportingDocuments/CAMARA-Release-Creation-Detailed-Design.md
+++ b/documentation/SupportingDocuments/CAMARA-Release-Creation-Detailed-Design.md
@@ -747,6 +747,7 @@ Permission is enforced by automation via GitHub API checks (repository permissio
 - Writable only by automation
 - Deletable only by automation (and admins as break-glass)
 - No direct pushes from humans
+- **Release PR approval**: Requires at least one codeowner AND at least one Release Management reviewer before merge
 
 **Release-review branches (`release-review/*`):**
 - Not protected

--- a/documentation/SupportingDocuments/CAMARA-Release-Workflow-and-Metadata-Concept.md
+++ b/documentation/SupportingDocuments/CAMARA-Release-Workflow-and-Metadata-Concept.md
@@ -176,7 +176,7 @@ Upon triggering the release (via `/create-snapshot` slash command in a Release I
 
 Manual review and adjustments happen through the Release PR (from release-review branch to snapshot branch).
 
-- Release PRs require approval from codeowner(s) and release reviewer(s) (via branch protection).
+- Release PRs require approval from at least one codeowner AND at least one Release Management reviewer (enforced via branch protection on snapshot branches).
 - Review covers CHANGELOG and README correctness wrt metadata
 - CHANGELOG.md entries may be refined on the release-review branch (codeowners commit directly; maintainers/contributors via PRs from forks)
 - Mechanical changes on the snapshot branch are protected and cannot be edited


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Adds detailed design document for the C2 release creation workflow and aligns the concept document terminology with the detailed design.

Key design elements:
- Slash commands for user intent (`/create-snapshot`, `/discard-snapshot`, `/revoke-draft`)
- Dual-branch model: snapshot (mechanical, automation-owned) + review (documentation, human-editable)
- `release-metadata.yaml` as source of truth on snapshot branch
- Comprehensive state model with clear transitions
- Bot UX contract for guided user experience
- Tag creation only at final publication (human checkpoint)

#### Which issue(s) this PR fixes:

Fixes #361

#### Special notes for reviewers:

This design refines and extends the C2 workflow from the concept document. The "Deviations from Current Concept" table in the design document summarizes the key differences.

#### Changelog input

```
release-note
Add C2 release creation detailed design document and align concept document terminology
```

#### Additional documentation 

```
docs
documentation/SupportingDocuments/CAMARA-Release-Creation-Detailed-Design.md
documentation/SupportingDocuments/CAMARA-Release-Workflow-and-Metadata-Concept.md
```