### PR TITLE
docs: add work-in-progress notice to release documentation

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,5 +1,7 @@
 # CAMARA Release Process Documentation
 
+> **Note:** This documentation and the described process are work in progress. For API repository releases during the Spring26 meta-release, please continue to use the documents in the [deprecated section](deprecated/README.md).
+
 ## Quick Start
 
 **I need to release an API** → [Release Process Guide](release-process/lifecycle.md)


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Adds a note block to the release documentation README clarifying that the documentation and process are work in progress. Directs users to the deprecated documents for API repository releases during the Spring26 meta-release.

#### Which issue(s) this PR fixes:

n/a

#### Special notes for reviewers:

Small documentation addition.

#### Changelog input

```
release-note
n/a
```

#### Additional documentation 

```
docs
n/a
```