### PR TITLE
fix: remove 'none' option from release_track

### DIFF
--- a/artifacts/metadata-schemas/README.md
+++ b/artifacts/metadata-schemas/README.md
@@ -44,7 +44,7 @@ metadata-schemas/
 Defines the structure for `release-plan.yaml` files maintained on the main branch.
 
 **Key fields:**
-- `repository.release_track` - Release track (none, independent, meta-release)
+- `repository.release_track` - Release track (independent, meta-release)
 - `repository.meta_release` - Meta-release label (Fall26, Spring27), required when release_track is "meta-release"
 - `repository.target_release_tag` - CAMARA release tag this release should have (e.g., r4.1), must be the next available number in the release cycle or rN+1.1 for start of new release cycle
 - `repository.target_release_type` - Declared release type, validated by CI against API statuses (none, pre-release-alpha, pre-release-rc, public-release, maintenance-release)
@@ -171,7 +171,7 @@ Recommended dependencies for JavaScript version:
 
 Use these exact field names:
 
-- `release_track` (none, independent, meta-release)
+- `release_track` (independent or meta-release)
 - `target_release_tag` (in release-plan.yaml) / `release_tag` (in release-metadata.yaml)
 - `api_name` (not name)
 - `commonalities_release` (not commonalities_version)
@@ -182,8 +182,7 @@ Use these exact field names:
 ### Release Track
 
 **release_track** determines how the repository participates in CAMARA releases:
-- `none` - No release planned
-- `independent` - Release outside meta-release cycle
+- `independent` - Release outside meta-release cycle (default)
 - `meta-release` - Participating in a CAMARA meta-release (requires meta_release field)
 
 ### Target Release Type vs Target API Status
@@ -254,7 +253,7 @@ pip install pyyaml jsonschema
 - **Fix:** Must be exactly: draft, alpha, rc, or public
 
 **Error:** "release_track is not one of enum values"
-- **Fix:** Must be exactly: none, independent, or meta-release
+- **Fix:** Must be exactly: independent or meta-release
 
 ### Semantic Errors
 

--- a/artifacts/metadata-schemas/schemas/release-plan-schema.yaml
+++ b/artifacts/metadata-schemas/schemas/release-plan-schema.yaml
@@ -22,11 +22,9 @@ properties:
         type: string
         description: |
           Release track determining how the repository participates in CAMARA releases:
-          - none: No release planned, other repository fields can be omitted
-          - independent: Release outside meta-release cycle
+          - independent: Release outside meta-release cycle (default)
           - meta-release: Participating in a CAMARA meta-release cycle (requires meta_release field)
         enum:
-          - "none"
           - "independent"
           - "meta-release"
 

--- a/artifacts/metadata-schemas/scripts/validate-release-plan.py
+++ b/artifacts/metadata-schemas/scripts/validate-release-plan.py
@@ -135,7 +135,7 @@ class MetadataValidator:
             self.errors.append(
                 "release_track is 'meta-release' but meta_release field is missing"
             )
-        elif release_track in ['none', 'independent'] and meta_release:
+        elif release_track == 'independent' and meta_release:
             self.warnings.append(
                 f"release_track is '{release_track}' but meta_release field is present"
             )

--- a/documentation/SupportingDocuments/CAMARA-Release-Workflow-and-Metadata-Concept.md
+++ b/documentation/SupportingDocuments/CAMARA-Release-Workflow-and-Metadata-Concept.md
@@ -31,7 +31,7 @@ The process achieves these objectives through:
 
 | Term                   | Description |
 |------------------------|-------------|
-| `release_track`        | Release track determining how repository participates: `none` (no release), `independent` (outside meta-release), `meta-release` (participating in meta-release). |
+| `release_track`        | Release track determining how repository participates: `independent` (outside meta-release, default), `meta-release` (participating in meta-release). |
 | `meta_release`         | Meta-release label (e.g., `Fall26`). Only used when `release_track` is `meta-release`. |
 | `target_release_tag`   | Target CAMARA release tag this release should have (e.g., `r4.1`). Distinct from API SemVer. |
 | `target_release_type`  | Codeowner-declared release type for next release, validated by CI: `none` (not ready), `pre-release-alpha` (requires all APIs at alpha+), `pre-release-rc` (requires all APIs at rc+), `public-release` (requires all APIs public), `maintenance-release` (maintenance). |
@@ -54,7 +54,7 @@ Planning metadata owned by codeowners, manually updated and CI-validated. Contai
 
 ```yaml
 repository:
-  release_track: meta-release  # none, independent, or meta-release
+  release_track: meta-release  # independent or meta-release
   meta_release: Fall26  # Only when release_track is meta-release
   target_release_tag: r4.1
   target_release_type: pre-release-alpha  # Repository ready for pre-release with mixed API status

--- a/documentation/metadata/release-plan.md
+++ b/documentation/metadata/release-plan.md
@@ -32,7 +32,7 @@ apis:
 
 | Field | Description |
 |-------|-------------|
-| `release_track` | `none`, `independent`, or `meta-release` (`none` = no release planned) |
+| `release_track` | `independent` (default) or `meta-release` |
 | `meta_release` | Meta-release cycle (e.g., `Fall26`) — required if track is `meta-release` |
 | `target_release_tag` | Release tag (e.g., `r4.1`) |
 | `target_release_type` | `none` (no release planned), `pre-release-alpha`, `pre-release-rc`, `public-release`, `maintenance-release` |


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Removes the ambiguous `none` option from the `release_track` enum in `release-plan.yaml`. The `none` value provided no behavioral difference from `independent` — a repository with `release_track: none` but a valid `target_release_type` would still get a Release Issue and go through the full release lifecycle.

The two valid values are now:
- `independent` (default): Repository releases independently
- `meta-release`: Repository participates in a meta-release cycle

#### Which issue(s) this PR fixes:

Fixes #375

#### Special notes for reviewers:

After this change, the following repositories need corresponding updates:
- `camaraproject/tooling`: Update validation rules for `release-plan.yaml`
- `camaraproject/project-administration`: Update the schema copy of `release-plan.yaml`

#### Changelog input

```
 release-note
Remove ambiguous 'none' option from release_track field in release-plan.yaml schema
```

#### Additional documentation

This section can be blank.

```
docs

```