### PR TITLE
docs: replace Fall26 with Sync26 in documentation

### DIFF
--- a/documentation/SupportingDocuments/CAMARA-Release-Creation-Detailed-Design.md
+++ b/documentation/SupportingDocuments/CAMARA-Release-Creation-Detailed-Design.md
@@ -501,7 +501,7 @@ When `/create-snapshot` is run, automation:
    - Creates `release-metadata.yaml` with base commit SHA and release configuration
    - Creates release-review branch `release-review/rX.Y-<shortsha>`
    - Commits automated updates for the release to CHANGELOG, README to the release-review branch
-   - Creates the Release PR: release-review → release-snapshot, titled `Release Review: {repo} {tag} ({type}{, meta})` (e.g., "Release Review: QualityOnDemand r4.1 (rc, Fall26)")
+   - Creates the Release PR: release-review → release-snapshot, titled `Release Review: {repo} {tag} ({type}{, meta})` (e.g., "Release Review: QualityOnDemand r4.1 (rc, Sync26)")
    - Updates the Release Issue label to `release-state: snapshot-active`
    - Posts success comment with links and next steps in the Release Issue
 
@@ -566,7 +566,7 @@ repository:
   release_type: pre-release-rc
   release_date: null                   # Set at publication
   src_commit_sha: abc1234def5678901234567890abcdef12345678  # Set at snapshot creation
-  release_notes: "Pre-release for CAMARA Fall26 meta-release."
+  release_notes: "Pre-release for CAMARA Sync26 meta-release."
 
 dependencies:
   commonalities_release: "r3.4 (1.2.0)"

--- a/documentation/SupportingDocuments/CAMARA-Release-Workflow-and-Metadata-Concept.md
+++ b/documentation/SupportingDocuments/CAMARA-Release-Workflow-and-Metadata-Concept.md
@@ -32,7 +32,7 @@ The process achieves these objectives through:
 | Term                   | Description |
 |------------------------|-------------|
 | `release_track`        | Release track determining how repository participates: `independent` (outside meta-release, default), `meta-release` (participating in meta-release). |
-| `meta_release`         | Meta-release label (e.g., `Fall26`). Only used when `release_track` is `meta-release`. |
+| `meta_release`         | Meta-release label (e.g., `Sync26`). Only used when `release_track` is `meta-release`. |
 | `target_release_tag`   | Target CAMARA release tag this release should have (e.g., `r4.1`). Distinct from API SemVer. |
 | `target_release_type`  | Codeowner-declared release type for next release, validated by CI: `none` (not ready), `pre-release-alpha` (requires all APIs at alpha+), `pre-release-rc` (requires all APIs at rc+), `public-release` (requires all APIs public), `maintenance-release` (maintenance). |
 | `target_api_status`    | Per-API target status for next release: `draft` (declared, basic validation), `alpha`, `rc`, `public`. Extension numbers are auto-calculated. |
@@ -55,7 +55,7 @@ Planning metadata owned by codeowners, manually updated and CI-validated. Contai
 ```yaml
 repository:
   release_track: meta-release  # independent or meta-release
-  meta_release: Fall26  # Only when release_track is meta-release
+  meta_release: Sync26  # Only when release_track is meta-release
   target_release_tag: r4.1
   target_release_type: pre-release-alpha  # Repository ready for pre-release with mixed API status
 
@@ -108,7 +108,7 @@ repository:
   release_date: 2025-11-22T14:30:00Z  # Actual release date and time in ISO 8601 format (UTC)
   release_type: pre-release-alpha
   src_commit_sha: abcd1234efgh5678  # Last commit from main or maintenance branch included in this release
-  release_notes: Pre-release for CAMARA Fall26 release cycle.
+  release_notes: Pre-release for CAMARA Sync26 release cycle.
 
 dependencies:
   commonalities_release: r4.2 (1.2.0-rc.1)
@@ -296,13 +296,13 @@ See Appendix for detailed branching diagrams and maintenance strategy.
 - Post-release: Generate and attach `release-metadata.yaml` as release artifacts (can be added after release)
 
 ### Spring26 (October 2025 - March 2026)
-- All repositories add `release-plan.yaml` with their planning e.g. for Fall26 (based on pre-populated file)
+- All repositories add `release-plan.yaml` with their planning e.g. for Sync26 (based on pre-populated file)
 - Auto-generate meta-release overview tables from YAML files
 - Wiki tracker pages deprecated (no longer maintained)
 - **Parallel operation**: Manual and automated release process (selected repositories as early adopters)
 - **Ambition**: Spring26 M4 milestone automated for all participating API repositories
 
-### Fall26 (April 2026)
+### Sync26 (April 2026)
 - Full automation implementation
 - Wiki completely deprecated
 - Mandatory adoption for all repositories

--- a/documentation/metadata/release-plan.md
+++ b/documentation/metadata/release-plan.md
@@ -12,7 +12,7 @@ The `release-plan.yaml` file declares your **intent** for the next release. It i
 ```yaml
 repository:
   release_track: meta-release
-  meta_release: Fall26
+  meta_release: Sync26
   target_release_tag: r4.1
   target_release_type: pre-release-rc
 
@@ -33,7 +33,7 @@ apis:
 | Field | Description |
 |-------|-------------|
 | `release_track` | `independent` (default) or `meta-release` |
-| `meta_release` | Meta-release cycle (e.g., `Fall26`) — required if track is `meta-release` |
+| `meta_release` | Meta-release cycle (e.g., `Sync26`) — required if track is `meta-release` |
 | `target_release_tag` | Release tag (e.g., `r4.1`) |
 | `target_release_type` | `none` (no release planned), `pre-release-alpha`, `pre-release-rc`, `public-release`, `maintenance-release` |
 

--- a/documentation/release-process/terminology.md
+++ b/documentation/release-process/terminology.md
@@ -14,7 +14,7 @@ These are independent numbering systems.
 
 **Release track:** How the repository participates in releases — `none`, `independent`, or `meta-release`.
 
-**Meta-release:** A coordinated CAMARA release cycle (e.g., `Fall26`).
+**Meta-release:** A coordinated CAMARA release cycle (e.g., `Sync26`).
 
 **Release type:** The maturity level of a repository release:
 


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Updates all documentation references from `Fall26` to `Sync26` to reflect the new meta-release naming convention (TSC decision 2026-02-19).

Files updated:
- `documentation/SupportingDocuments/CAMARA-Release-Workflow-and-Metadata-Concept.md` (5 occurrences)
- `documentation/SupportingDocuments/CAMARA-Release-Creation-Detailed-Design.md` (2 occurrences)
- `documentation/release-process/terminology.md` (1 occurrence)
- `documentation/metadata/release-plan.md` (2 occurrences)

The corresponding schema and example updates are in PR #382.

#### Which issue(s) this PR fixes:

Fixes #383

#### Special notes for reviewers:

Straightforward find-and-replace of `Fall26` → `Sync26`. No `Spring27` occurrences existed in these files.

#### Changelog input

n/a (documentation only)