### PR TITLE
Add Release Progress Tracker caller workflow

### DIFF
--- a/.github/workflows/release-progress-tracker.yml
+++ b/.github/workflows/release-progress-tracker.yml
@@ -1,0 +1,38 @@
+# Release Progress Tracker — Caller Workflow
+#
+# Calls the reusable workflow in project-administration which collects
+# progress data, generates the HTML viewer, deploys it to this repo's
+# GitHub Pages, and opens a PR with updated data.
+#
+# Prerequisites:
+#   - GitHub Pages enabled (source: GitHub Actions) in repo settings
+#   - Label "release-progress" created (or let peter-evans/create-pull-request auto-create)
+#
+# Fork testing:
+#   Change the 'uses' line below to point at your fork/branch, e.g.:
+#     uses: hdamker/project-administration/.github/workflows/release-progress-tracker.yml@release-progress-tracker
+
+name: Release Progress Tracker
+
+on:
+  schedule:
+    - cron: '23 5 * * *'   # Daily at 05:23 UTC
+    - cron: '23 14 * * *'  # Daily at 14:23 UTC
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Enable debug logging'
+        type: boolean
+        default: false
+
+jobs:
+  track-progress:
+    uses: camaraproject/project-administration/.github/workflows/release-progress-tracker.yml@main
+    with:
+      debug: ${{ inputs.debug || false }}
+    secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
+      pages: write
+      id-token: write


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Adds a caller workflow that triggers the Release Progress Tracker ([project-administration#108](https://github.com/camaraproject/project-administration/issues/108)) to collect release progress data and deploy an interactive viewer to this repository's GitHub Pages.

**What the workflow does:**
- Runs twice daily at 05:23 and 14:23 UTC (and on manual dispatch)
- Calls the reusable workflow in project-administration
- Scans all CAMARA API repositories for release-plan.yaml
- Derives release state from repository artifacts (branches, releases, tags)
- Generates an HTML progress viewer deployed to GitHub Pages
- Opens a PR with updated data in `data/releases-progress.yaml`

**Prerequisite**: GitHub Pages enabled (source: GitHub Actions) — already done.

#### Which issue(s) this PR fixes:

Fixes #390

#### Special notes for reviewers:

- The caller workflow is thin (38 lines) — all logic lives in the [reusable workflow in project-administration](https://github.com/camaraproject/project-administration/blob/main/.github/workflows/release-progress-tracker.yml)
- Fork-tested on [hdamker/ReleaseManagement](https://hdamker.github.io/ReleaseManagement/) — all 4 jobs pass
- The first successful run will create `data/releases-progress.yaml` via PR

#### Changelog input

```release
Add Release Progress Tracker caller workflow for automated release progress monitoring
```

#### Additional documentation

See [Release Progress Tracker README](https://github.com/camaraproject/project-administration/blob/main/workflows/release-progress-tracker/README.md) for architecture details.