### PR TITLE
Add API Readiness Checklist content

### DIFF
--- a/documentation/readiness/api-readiness-checklist.md
+++ b/documentation/readiness/api-readiness-checklist.md
@@ -21,7 +21,7 @@ Release readiness is tracked through `release-plan.yaml` configuration, release 
 | Initial public | Derived | API status is `public` and major version is 0 (e.g., v0.5.0) |
 | Stable public | Derived | API status is `public` and major version ≥ 1 (e.g., v1.0.0) |
 
-The Release Issue and Release PR embed the readiness matrix as a convenience copy; this document is the canonical source.
+The Release Issue and Release PR embed the readiness matrix as a convenience copy; this document holds the reference source.
 
 ## Release Assets
 


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Replaces the placeholder in `documentation/readiness/api-readiness-checklist.md` with full content:

- Release assets table (8 items with descriptions, locations, automation status, verification guidance)
- M/O matrix by API status (alpha, rc, initial public, stable public)
- Preparation prerequisites before `/create-snapshot`
- Release readiness review process (codeowner vs release management, permanent vs introduction-phase items)

#### Which issue(s) this PR fixes:

Fixes #388
Supersedes #389

#### Special notes for reviewers:

This content was developed and reviewed as part of [camaraproject/tooling#90](https://github.com/camaraproject/tooling/pull/90) (approved by @tanjadegroot). It is contributed here as the canonical location for the API Readiness Checklist documentation.