### PR TITLE
docs: add release pointer branches to documentation

### DIFF
--- a/documentation/release-process/lifecycle.md
+++ b/documentation/release-process/lifecycle.md
@@ -89,6 +89,7 @@ This phase is ongoing until you decide to release.
 
 **What you see:**
 - Release tag `rX.Y` created
+- Pointer branch created (`release/rX.Y` or `pre-release/rX.Y`) at the tag commit
 - Post-release sync PR created (merge it to update `main`)
 - Release Issue closed
 

--- a/documentation/release-process/terminology.md
+++ b/documentation/release-process/terminology.md
@@ -37,6 +37,8 @@ These are independent numbering systems.
 
 **Release tag:** Git tag marking a published release (e.g., `r4.1`).
 
+**Release pointer branch:** A branch (`release/rX.Y` for public releases, `pre-release/rX.Y` for pre-releases) created by the automation at the release tag commit. Prevents the GitHub "commit does not belong to any branch" warning when browsing the tag tree view.
+
 ## Release States
 
 | State | Meaning |


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Documents release pointer branches (`release/rX.Y` for public releases, `pre-release/rX.Y` for pre-releases) created by the release automation after publication. These branches prevent GitHub's "commit does not belong to any branch" warning when browsing the tag tree view.

Changes:
- terminology.md: add release pointer branch definition
- lifecycle.md: add pointer branch to publish step output
- Detailed Design: add publication flow step, new Section 8.2, update branch cleanup table

#### Which issue(s) this PR fixes:

Relates to #393

#### Special notes for reviewers:

Implementation PRs for camaraproject/tooling and camaraproject/project-administration will follow. This documentation PR should be merged first.

#### Changelog input

```
 release-note
Add release pointer branches to release process documentation
```

#### Additional documentation

This section can be blank.

```
docs

```