### PR TITLE
docs: rename post-release sync branch to pr-to-main/{release_tag}

### DIFF
--- a/documentation/SupportingDocuments/CAMARA-Release-Creation-Detailed-Design.md
+++ b/documentation/SupportingDocuments/CAMARA-Release-Creation-Detailed-Design.md
@@ -1168,7 +1168,7 @@ Automation creates a PR to sync release artifacts back to main.
 
 | Aspect | Specification |
 |--------|---------------|
-| Branch | `tmp/sync-main/rX.Y` → main |
+| Branch | `pr-to-main/rX.Y` → main |
 | Content | CHANGELOG entry, README release info section |
 | Labels | `post-release`, `automated` |
 | Review | Requests CODEOWNERS review |
@@ -1186,7 +1186,7 @@ Automation creates a PR to sync release artifacts back to main.
 |--------|--------|
 | `release-snapshot/rX.Y-{sha}` | Deleted (tag and pointer branch preserve content) |
 | `release-review/rX.Y-{sha}` | Deleted (content preserved in release tag) |
-| `tmp/sync-main/rX.Y` | Deleted by GitHub on PR merge |
+| `pr-to-main/rX.Y` | Deleted by GitHub on PR merge |
 | `release/rX.Y` | Kept (protected pointer to tag commit) |
 | `pre-release/rX.Y` | Kept (deletable by codeowners when superseded) |
 


### PR DESCRIPTION
#### What type of PR is this?

Documentation update

#### What this PR does / why we need it:

Updates the detailed design document to reflect the renamed post-release sync branch from `post-release/rX.Y` to `pr-to-main/rX.Y`. The `pr-to-main/` prefix clearly signals the branch is for creating a PR back to main — avoiding confusion with the permanent `pre-release/rX.Y` pointer branch.

#### Which issue(s) this PR fixes:

Related: camaraproject/tooling#98 (implementation change)

#### Special notes for reviewers:

Two occurrences in Section 8 (Post-Release Automation) of `CAMARA-Release-Creation-Detailed-Design.md`:
- Section 8.3: Sync PR specification table (branch name)
- Section 8.4: Branch cleanup table (branch lifecycle)

All other "post-release" references in the doc are descriptive text (e.g., "post-release sync PR", "Post-Release Automation") and remain unchanged.

#### Changelog input

```
release-note
n/a
```

#### Additional documentation

```
docs
Updated CAMARA-Release-Creation-Detailed-Design.md Section 8.3 and 8.4
```