### PR TITLE
docs: clarify CHANGELOG editing workflow and post-publish branch cleanup

### DIFF
--- a/documentation/release-process/lifecycle.md
+++ b/documentation/release-process/lifecycle.md
@@ -64,7 +64,10 @@ This phase is ongoing until you decide to release.
 ### 4. Review and Approve
 
 **What you do:**
-1. Review the Release PR (CHANGELOG entry for the release) and update as needed.
+1. Review the Release PR and complete the CHANGELOG entry:
+   - The automation generates `CHANGELOG/CHANGELOG-rX.md` on the release-review branch with placeholder text in the Added/Changed/Fixed/Removed sections
+   - Fill in those sections by committing directly to the release-review branch
+   - Do **not** create a separate PR to `main` for the CHANGELOG — the post-release sync PR (created automatically after publish) will bring it back to `main`
 2. Ensure required approvals are in place (codeowner and release reviewer)
 3. Merge the Release PR
 
@@ -92,6 +95,16 @@ This phase is ongoing until you decide to release.
 - Pointer branch created (`release/rX.Y` or `pre-release/rX.Y`) at the tag commit
 - Post-release sync PR created (merge it to update `main`)
 - Release Issue closed
+
+**After merging the post-release sync PR:**
+
+Three branches remain after a successful publish. Here is what to do with each:
+
+| Branch | Purpose | Action |
+|--------|---------|--------|
+| `release-review/rX.Y-<id>-published` | The completed release-review branch, renamed on publish | Delete |
+| `pr-to-main/rX.Y` | Source branch for the post-release sync PR | Delete after sync PR is merged |
+| `pre-release/rX.Y` (or `release/rX.Y`) | Pointer to the release tag | Keep as long as the release is listed in the repo README |
 
 **What can block you:**
 - Issue found in draft:

--- a/documentation/release-process/terminology.md
+++ b/documentation/release-process/terminology.md
@@ -39,6 +39,10 @@ These are independent numbering systems.
 
 **Release pointer branch:** A branch (`release/rX.Y` for public releases, `pre-release/rX.Y` for pre-releases) created by the automation at the release tag commit. Prevents the GitHub "commit does not belong to any branch" warning when browsing the tag tree view.
 
+**Release-review branch:** The editable branch created by the automation when a snapshot is taken, named `release-review/rX.Y-<snapshot-id>`. This is where the CHANGELOG is completed during release review. Renamed to `release-review/rX.Y-<snapshot-id>-published` after the release is published, and can then be deleted.
+
+**`pr-to-main` branch:** The source branch for the post-release sync PR, named `pr-to-main/rX.Y`. Created automatically on publish to carry the CHANGELOG and README updates back to `main`. Can be deleted once the sync PR is merged.
+
 ## Release States
 
 | State | Meaning |


### PR DESCRIPTION
## Summary

- Expands Step 4 of `lifecycle.md` to clarify that the CHANGELOG is completed by committing directly to the release-review branch, not via a separate PR to `main`
- Adds a branch cleanup table to Step 5 of `lifecycle.md` covering the three branches left after publish
- Adds definitions for the release-review branch and `pr-to-main` branch to `terminology.md`

Fixes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)