### PR TITLE
docs: align Validation Framework design with current app org-variable names

### DIFF
--- a/documentation/SupportingDocuments/CAMARA-Validation-Framework-Detailed-Design.md
+++ b/documentation/SupportingDocuments/CAMARA-Validation-Framework-Detailed-Design.md
@@ -374,7 +374,8 @@ A dedicated GitHub App handles write surfaces for validation. This is a **separa
 | **EasyCLA** | Not needed (no commits) | Required (commits to repos with CLA enforcement) |
 
 Org-level configuration:
-- `vars.VALIDATION_APP_ID` — app ID (org variable)
+- `vars.VALIDATION_APP_CLIENT_ID` — app client ID (org variable)
+- `vars.VALIDATION_APP_SLUG` — app slug, used for bot username (org variable)
 - `secrets.VALIDATION_APP_PRIVATE_KEY` — app private key (org secret)
 
 The validation app is introduced from day one (MVP) to establish consistent bot identity and avoid caller workflow changes later.
@@ -530,7 +531,7 @@ The reusable workflow uses a floating version tag (`v1`) analogous to v0's `v0` 
 The caller passes `secrets: inherit`. The reusable workflow uses:
 - `GITHUB_TOKEN` — inherited, for checkout and fallback write surfaces
 - Org secrets for validation app token minting (`VALIDATION_APP_PRIVATE_KEY`) — accessed via `secrets` context
-- Org variables for app identity (`VALIDATION_APP_ID`) — accessed via `vars` context
+- Org variables for app identity (`VALIDATION_APP_CLIENT_ID`, `VALIDATION_APP_SLUG`) — accessed via `vars` context
 
 ---
 


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Two lines in `CAMARA-Validation-Framework-Detailed-Design.md` referenced the validation app's identity org variable as `VALIDATION_APP_ID`. The actual org variables in use on `camaraproject` are `VALIDATION_APP_CLIENT_ID` and `VALIDATION_APP_SLUG`; the secret remains `VALIDATION_APP_PRIVATE_KEY`. Aligns the doc with the implementation on `tooling/main` and `project-administration/main`.

#### Which issue(s) this PR fixes:

N/A — housekeeping, no separate tracking issue.

#### Special notes for reviewers:

Doc-only change to a single file (3 insertions, 2 deletions). No code or workflow impact.

#### Changelog input

```
 release-note
 NONE

```

#### Additional documentation

This section can be blank.

```
 docs

```
