### PR TITLE
docs(release-process): describe generated CHANGELOG sentence and N/A defaults

### DIFF
--- a/documentation/release-process/lifecycle.md
+++ b/documentation/release-process/lifecycle.md
@@ -67,8 +67,8 @@ This phase is ongoing until you decide to release.
 **What you do:**
 
 1. **Edit `CHANGELOG-rX.md` on the release-review branch.**
-   - The automation pre-fills it with a temporary section listing the PRs merged since the previous release, plus placeholder Added / Changed / Fixed / Removed sections (each marked `_To be filled during release review_`).
-   - Move the entries from the temporary section into the appropriate placeholder sections (or drop sections that don't apply) and commit directly to the release-review branch.
+   - The automation pre-fills it with a temporary section listing the PRs merged since the relevant previous release, plus — for each API in the release — a generated first sentence describing that API's version and Added / Changed / Fixed / Removed sections each defaulting to `N/A`.
+   - For each API, move the relevant entries from the temporary section into that API's sections, replacing `N/A` with entries as applicable and leaving `N/A` where a category has no changes. Refine the generated first sentence if needed. Commit directly to the release-review branch.
 2. **Ensure required approvals are in place** (codeowner and release reviewer). The release reviewer reviews the Release PR; address CHANGELOG feedback with further commits to the release-review branch.
 3. **Merge the Release PR.**
 


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Aligns the release-review guidance with the updated CHANGELOG automation (camaraproject/tooling#312). The "Edit `CHANGELOG-rX.md`" step now describes that each API gets a generated first sentence and change sections defaulting to `N/A` — replaced as applicable, and validly left where a category has no changes. The per-API loop is made explicit so multi-API releases are handled correctly.

#### Which issue(s) this PR fixes:

Part of #552

<!-- Intentionally not "Fixes": #552 stays open until tooling#312 is included in the v1-rc reference and available to all repos; it will be closed manually at that point. -->

#### Special notes for reviewers:

Documentation-only. The behavior it describes ships in camaraproject/tooling#312 (merged).

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation

This section can be blank.

```
docs
```
