### PR TITLE
Add CAMARA Validation result handling to the API readiness checklist documentation

### DIFF
--- a/documentation/readiness/api-readiness-checklist.md
+++ b/documentation/readiness/api-readiness-checklist.md
@@ -64,7 +64,7 @@ Before issuing `/create-snapshot` on the Release Issue, codeowners must verify t
 
 - **`release-plan.yaml` content matches intent**: Check that API names, target versions, target statuses, and release type in `release-plan.yaml` are correct
 - **Dependency versions are current**: Commonalities and ICM dependency versions in `release-plan.yaml` should reference the latest recommended releases
-- **CI checks are green**: Spectral linting and PR validation should pass on `main`
+- **Validation checks pass**: Spectral linting and PR validation must pass on `main` - see below for handling validation results
 - **All intended PRs are merged**: Implementation work should be complete on `main`
 - **SemVer is correct**: Breaking changes are only allowed in initial versions (v0.x) or new major versions
 - **Release assets are provided**: All mandatory assets for the declared target API status(s) are in place (see matrix above)
@@ -72,6 +72,14 @@ Before issuing `/create-snapshot` on the Release Issue, codeowners must verify t
 These items appear as a preparation checklist in the Release Issue while it is in PLANNED state. They are reminders, not automated gates — the codeowner is responsible for verifying them before proceeding.
 
 > **Note**: During development on `main`, API version fields in the YAML definitions must stay as `wip`. The release automation process replaces them with the correct version numbers and applicable extensions during snapshot creation.
+
+### Handling validation results 
+
+Validation results must be handled as early as possible, and at the latest before the final rc pre-release, as follows:
+
+- Errors MUST be fixed (errors block snapshot creation).
+- Warnings MUST be fixed, or explicitly deferred by documenting them in an issue (copying the validation summary lines) with a deferral reason per line. For example, for stable APIs, a warning that would need a breaking change while no major version update is planned is a valid deferral reason.
+- Hints MUST be checked and MAY be fixed (hints do not block snapshot creataion nor a release-review).
 
 ## Release Readiness Reviews
 
@@ -86,6 +94,7 @@ Codeowners verify content accuracy:
 - API definitions are correct and complete for the target status
 - Test cases cover the intended API behavior
 - Documentation is adequate for the target audience
+- Document deferred warnings and the reason in an issue.
 
 ### Release Management Review
 
@@ -94,6 +103,7 @@ Release management reviewers verify process compliance:
 - CHANGELOG follows the release documentation rules
 - Breaking changes are documented and version updates follow SemVer rules
 - All mandatory release assets for the declared API(s) status(es) are present as per the checklist
+- Check and decide whether the warning deferrals are acceptable
 
 **During the automation introduction phase**, release management additionally verifies:
 

--- a/documentation/readiness/api-readiness-checklist.md
+++ b/documentation/readiness/api-readiness-checklist.md
@@ -76,11 +76,11 @@ These items appear as a preparation checklist in the Release Issue while it is i
 
 ### Handling validation results 
 
-Validation results must be handled as early as possible (controlled in each pre-release) as follows:
+Validation results must be handled as early as possible during each release preparation, and no later than before the final rc pre-release:
 
 - Errors MUST be fixed (errors block snapshot creation).
-- Warnings MUST be fixed, or explicitly deferred by documenting them in an issue (copying the validation summary lines) with a deferral reason per line. For example, for stable APIs, a warning that would need a breaking change while no major version update is planned is a valid deferral reason.
-- Hints MUST be checked and MAY be fixed (hints do not block snapshot creataion nor a release-review).
+- Warnings MUST be fixed or explicitly deferred by documenting them in one or more issues. The issue(s) must copy the relevant validation summary lines and include the deferral reason(s). For stable APIs, a warning that would require a breaking change while no major version update is planned is a valid deferral reason.
+- Hints MUST be checked and MAY be fixed. Hints do not block snapshot creation or Release PR review.
 
 Any warnings remaining in the final rc pre-release must have a valid deferral reason documented and need to be approved by Release Management.
 
@@ -97,7 +97,7 @@ Codeowners verify content accuracy:
 - API definitions are correct and complete for the target status
 - Test cases cover the intended API behavior
 - Documentation is adequate for the target audience
-- Any remaining warnings are documented in an issue stating an explicit deferreal reason
+- Any remaining warnings are documented in one or more issues, with the relevant validation summary lines and deferral reason(s)
 
 ### Release Management Review
 
@@ -106,7 +106,7 @@ Release management reviewers verify process compliance:
 - CHANGELOG follows the release documentation rules
 - Breaking changes are documented and version updates follow SemVer rules
 - All mandatory release assets for the declared API(s) status(es) are present as per the checklist
-- All remaining warnings have an acceptable deferral reason
+- All remaining warnings have been documented and have acceptable deferral reasons
 
 The Release PR contains a status-specific review checklist that reflects the requirements for the repository's release type.
 

--- a/documentation/readiness/api-readiness-checklist.md
+++ b/documentation/readiness/api-readiness-checklist.md
@@ -95,7 +95,7 @@ Codeowners verify content accuracy:
 - API definitions are correct and complete for the target status
 - Test cases cover the intended API behavior
 - Documentation is adequate for the target audience
-- Document deferred warnings and the reason in an issue.
+- Any remaining warnings are documented in an issue stating an explicit deferreal reason
 
 ### Release Management Review
 
@@ -104,7 +104,7 @@ Release management reviewers verify process compliance:
 - CHANGELOG follows the release documentation rules
 - Breaking changes are documented and version updates follow SemVer rules
 - All mandatory release assets for the declared API(s) status(es) are present as per the checklist
-- Check and decide whether the warning deferrals are acceptable
+- All remaining warnings have an acceptable deferral reason
 
 The Release PR contains a status-specific review checklist that reflects the requirements for the repository's release type.
 

--- a/documentation/readiness/api-readiness-checklist.md
+++ b/documentation/readiness/api-readiness-checklist.md
@@ -9,6 +9,7 @@ Before an API repository can be released, codeowners must ensure that certain as
 - Defines the required release assets and their expected locations
 - Specifies which assets are mandatory (M) or optional (O) per API status
 - Clarifies the division of responsibility: **codeowners prepare** the assets, **automation validates** what it can, and **release management reviewers** verify the rest
+- Explains how to handle CAMARA Validation results (errors, warnings and hints)
 
 Release readiness is tracked through `release-plan.yaml` configuration, release content preparation as indicated in the Release Issue, and the review checklist in the Release PR.
 
@@ -104,12 +105,6 @@ Release management reviewers verify process compliance:
 - Breaking changes are documented and version updates follow SemVer rules
 - All mandatory release assets for the declared API(s) status(es) are present as per the checklist
 - Check and decide whether the warning deferrals are acceptable
-
-**During the automation introduction phase**, release management additionally verifies:
-
-- `release-metadata.yaml` content is correct
-- API version generation was done correctly by automation (server URLs, references, version fields)
-- README update looks correct (release tag, versions, latest vs pre-release)
 
 The Release PR contains a status-specific review checklist that reflects the requirements for the repository's release type.
 

--- a/documentation/readiness/api-readiness-checklist.md
+++ b/documentation/readiness/api-readiness-checklist.md
@@ -82,7 +82,7 @@ Validation results must be handled as early as possible (controlled in each pre-
 - Warnings MUST be fixed, or explicitly deferred by documenting them in an issue (copying the validation summary lines) with a deferral reason per line. For example, for stable APIs, a warning that would need a breaking change while no major version update is planned is a valid deferral reason.
 - Hints MUST be checked and MAY be fixed (hints do not block snapshot creataion nor a release-review).
 
-Any warnings remaining in the final rc pre-release must have a valid deferral reason documented and needs to be approved by Release Management.
+Any warnings remaining in the final rc pre-release must have a valid deferral reason documented and need to be approved by Release Management.
 
 ## Release Readiness Reviews
 

--- a/documentation/readiness/api-readiness-checklist.md
+++ b/documentation/readiness/api-readiness-checklist.md
@@ -76,11 +76,13 @@ These items appear as a preparation checklist in the Release Issue while it is i
 
 ### Handling validation results 
 
-Validation results must be handled as early as possible, and at the latest before the final rc pre-release, as follows:
+Validation results must be handled as early as possible (controlled in each pre-release) as follows:
 
 - Errors MUST be fixed (errors block snapshot creation).
 - Warnings MUST be fixed, or explicitly deferred by documenting them in an issue (copying the validation summary lines) with a deferral reason per line. For example, for stable APIs, a warning that would need a breaking change while no major version update is planned is a valid deferral reason.
 - Hints MUST be checked and MAY be fixed (hints do not block snapshot creataion nor a release-review).
+
+Any warnings remaining in the final rc pre-release must have a valid deferral reason documented and needs to be approved by Release Management.
 
 ## Release Readiness Reviews
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature
* documentation

#### What this PR does / why we need it:
The handling of Validation results was not explicitly documented sofar. 
this PR add the rules agreed during the TSC on June 4, 2026.

It also removes the temporary statement on checking automation process functioning as this is now considered stable.

#### Which issue(s) this PR fixes:

Fixes #566 